### PR TITLE
Add path not exists exception which specifies the path

### DIFF
--- a/src/ParallelDriver.php
+++ b/src/ParallelDriver.php
@@ -216,7 +216,7 @@ final class ParallelDriver implements Driver
             if ($stat["mode"] & 0100000) {
                 return $stat["size"];
             }
-            throw new FilesystemException(sprintf('Specified path "%s" is not a regular file', $path));
+            throw new FilesystemException(\sprintf('Specified path "%s" is not a regular file', $path));
         });
     }
 

--- a/src/ParallelDriver.php
+++ b/src/ParallelDriver.php
@@ -211,12 +211,12 @@ final class ParallelDriver implements Driver
         return call(function () use ($path) {
             $stat = yield $this->stat($path);
             if (empty($stat)) {
-                throw new FilesystemException("Specified path does not exist");
+                throw new PathDoesNotExistException($path);
             }
             if ($stat["mode"] & 0100000) {
                 return $stat["size"];
             }
-            throw new FilesystemException("Specified path is not a regular file");
+            throw new FilesystemException(sprintf('Specified path "%s" is not a regular file', $path));
         });
     }
 
@@ -228,7 +228,7 @@ final class ParallelDriver implements Driver
         return call(function () use ($path) {
             $stat = yield $this->stat($path);
             if (empty($stat)) {
-                throw new FilesystemException("Specified path does not exist");
+                throw new PathDoesNotExistException($path);
             }
             return $stat["mtime"];
         });
@@ -242,7 +242,7 @@ final class ParallelDriver implements Driver
         return call(function () use ($path) {
             $stat = yield $this->stat($path);
             if (empty($stat)) {
-                throw new FilesystemException("Specified path does not exist");
+                throw new PathDoesNotExistException($path);
             }
             return $stat["atime"];
         });
@@ -256,7 +256,7 @@ final class ParallelDriver implements Driver
         return call(function () use ($path) {
             $stat = yield $this->stat($path);
             if (empty($stat)) {
-                throw new FilesystemException("Specified path does not exist");
+                throw new PathDoesNotExistException($path);
             }
             return $stat["ctime"];
         });

--- a/src/PathDoesNotExistException.php
+++ b/src/PathDoesNotExistException.php
@@ -2,7 +2,7 @@
 
 namespace Amp\File;
 
-class PathDoesNotExistException extends FileSystemException
+class PathDoesNotExistException extends FilesystemException
 {
     private $path;
 

--- a/src/PathDoesNotExistException.php
+++ b/src/PathDoesNotExistException.php
@@ -4,8 +4,16 @@ namespace Amp\File;
 
 class PathDoesNotExistException extends FileSystemException
 {
+    private $path;
+
     public function __construct(string $path)
     {
+        $this->path = $path;
         parent::__construct(sprintf('Specified path "%s" does not exist', $path));
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
     }
 }

--- a/src/PathDoesNotExistException.php
+++ b/src/PathDoesNotExistException.php
@@ -9,7 +9,7 @@ class PathDoesNotExistException extends FileSystemException
     public function __construct(string $path)
     {
         $this->path = $path;
-        parent::__construct(sprintf('Specified path "%s" does not exist', $path));
+        parent::__construct(\sprintf('Specified path "%s" does not exist', $path));
     }
 
     public function getPath(): string

--- a/src/PathDoesNotExistException.php
+++ b/src/PathDoesNotExistException.php
@@ -2,8 +2,6 @@
 
 namespace Amp\File;
 
-use Exception;
-
 class PathDoesNotExistException extends FileSystemException
 {
     public function __construct(string $path)

--- a/src/PathDoesNotExistException.php
+++ b/src/PathDoesNotExistException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Amp\File;
+
+use Exception;
+
+class PathDoesNotExistException extends FileSystemException
+{
+    public function __construct(string $path)
+    {
+        parent::__construct(sprintf('Specified path "%s" does not exist', $path));
+    }
+}


### PR DESCRIPTION
Specify the path which doesn't exist when the path doesn't exist.

<strike>I can't test this locally as I don't have the necessary extensions (eio, uv) to install the dev dependencies.</strike> I manually deleted the extension deps from composer.

Looks like you also need to update Travis - the legacy integrations have broken.. (you can migrate [here](https://travis-ci.com/account/repositories) )