### PR TITLE
Fix r+ permission writeable check

### DIFF
--- a/src/Internal/QueuedWritesFile.php
+++ b/src/Internal/QueuedWritesFile.php
@@ -38,7 +38,7 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
         }
 
         $this->queue = new \SplQueue();
-        $this->writable = $this->mode[0] !== 'r';
+        $this->writable = $this->mode[0] !== 'r' || $this->mode == 'r+';
         $this->position = $this->mode[0] === 'a' ? $this->size : 0;
     }
 

--- a/src/Internal/QueuedWritesFile.php
+++ b/src/Internal/QueuedWritesFile.php
@@ -38,7 +38,10 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
         }
 
         $this->queue = new \SplQueue();
-        $this->writable = $this->mode[0] !== 'r' || $this->mode == 'r+';
+        $this->writable = match ($this->mode) {
+            'r', 'rb' => false,
+            default => true,
+        };
         $this->position = $this->mode[0] === 'a' ? $this->size : 0;
     }
 


### PR DESCRIPTION
The r+ mode for opening a file is similar to r mode but has some added features. It opens the file in both read and write mode.