### PR TITLE
Add the promised FileCache class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,11 +59,13 @@
     "autoload-dev": {
         "psr-4": {
             "Amp\\File\\Test\\": "test",
+            "Amp\\Cache\\Test\\": "vendor/amphp/cache/test",
             "Amp\\Sync\\": "vendor/amphp/sync/test"
         }
     },
     "config": {
         "preferred-install": {
+            "amphp/cache": "source",
             "amphp/sync": "source"
         }
     },

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -22,12 +22,12 @@ final class FileCache implements StringCache
 
     private readonly string $directory;
 
-    private ?string $gcWatcher = null;
+    private ?string $gcWatcher;
 
     public function __construct(
         string $directory,
         private readonly KeyedMutex $mutex,
-        ?Filesystem $filesystem = null
+        ?Filesystem $filesystem = null,
     ) {
         $filesystem ??= filesystem();
         $this->filesystem = $filesystem;
@@ -87,7 +87,6 @@ final class FileCache implements StringCache
         }
     }
 
-    /** @inheritdoc */
     public function get(string $key): ?string
     {
         $filename = $this->getFilename($key);
@@ -120,7 +119,6 @@ final class FileCache implements StringCache
         }
     }
 
-    /** @inheritdoc */
     public function set(string $key, string $value, int $ttl = null): void
     {
         if ($ttl < 0) {
@@ -146,7 +144,6 @@ final class FileCache implements StringCache
         }
     }
 
-    /** @inheritdoc */
     public function delete(string $key): ?bool
     {
         $filename = $this->getFilename($key);
@@ -160,6 +157,7 @@ final class FileCache implements StringCache
         } finally {
             $lock->release();
         }
+
         return true;
     }
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -29,7 +29,8 @@ final class FileCache implements StringCache
         private readonly KeyedMutex $mutex,
         ?Filesystem $filesystem = null,
     ) {
-        $this->filesystem = $filesystem ?? filesystem();
+        $filesystem ??= filesystem();
+        $this->filesystem = $filesystem;
         $this->directory = $directory = \rtrim($directory, "/\\");
 
         $gcWatcher = static function () use ($directory, $mutex, $filesystem): void {

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -29,8 +29,7 @@ final class FileCache implements StringCache
         private readonly KeyedMutex $mutex,
         ?Filesystem $filesystem = null,
     ) {
-        $filesystem ??= filesystem();
-        $this->filesystem = $filesystem;
+        $this->filesystem = $filesystem ?? filesystem();
         $this->directory = $directory = \rtrim($directory, "/\\");
 
         $gcWatcher = static function () use ($directory, $mutex, $filesystem): void {

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -1,0 +1,183 @@
+<?php declare(strict_types=1);
+
+namespace Amp\File;
+
+use Amp\Cache\CacheException;
+use Amp\Cache\StringCache;
+use Amp\ForbidCloning;
+use Amp\ForbidSerialization;
+use Amp\Sync\KeyedMutex;
+use Amp\Sync\Lock;
+use Revolt\EventLoop;
+
+/**
+ * A cache which stores data in files in a directory.
+ */
+final class FileCache implements StringCache
+{
+    use ForbidCloning;
+    use ForbidSerialization;
+
+    private readonly Filesystem $filesystem;
+
+    private readonly string $directory;
+
+    private ?string $gcWatcher = null;
+
+    public function __construct(
+        string $directory,
+        private readonly KeyedMutex $mutex,
+        ?Filesystem $filesystem = null
+    ) {
+        $filesystem ??= filesystem();
+        $this->filesystem = $filesystem;
+        $this->directory = $directory = \rtrim($directory, "/\\");
+
+        $gcWatcher = static function () use ($directory, $mutex, $filesystem): void {
+            try {
+                $files = $filesystem->listFiles($directory);
+
+                foreach ($files as $file) {
+                    if (\strlen($file) !== 70 || !\str_ends_with($file, '.cache')) {
+                        continue;
+                    }
+
+                    try {
+                        $lock = $mutex->acquire($file);
+                    } catch (\Throwable) {
+                        continue;
+                    }
+
+                    try {
+                        $handle = $filesystem->openFile($directory . '/' . $file, 'r');
+                        $ttl = $handle->read(length: 4);
+
+                        if ($ttl === null || \strlen($ttl) !== 4) {
+                            $handle->close();
+                            continue;
+                        }
+
+                        $ttl = \unpack('Nttl', $ttl)['ttl'];
+                        if ($ttl < \time()) {
+                            $filesystem->deleteFile($directory . '/' . $file);
+                        }
+                    } catch (\Throwable) {
+                        // ignore
+                    } finally {
+                        $lock->release();
+                    }
+                }
+            } catch (\Throwable) {
+                // ignore
+            }
+        };
+
+        // trigger once, so short running scripts also GC and don't grow forever
+        EventLoop::defer($gcWatcher);
+
+        $this->gcWatcher = EventLoop::repeat(300, $gcWatcher);
+
+        EventLoop::unreference($this->gcWatcher);
+    }
+
+    public function __destruct()
+    {
+        if ($this->gcWatcher !== null) {
+            EventLoop::cancel($this->gcWatcher);
+        }
+    }
+
+    /** @inheritdoc */
+    public function get(string $key): ?string
+    {
+        $filename = $this->getFilename($key);
+
+        $lock = $this->lock($filename);
+
+        try {
+            $cacheContent = $this->filesystem->read($this->directory . '/' . $filename);
+
+            if (\strlen($cacheContent) < 4) {
+                return null;
+            }
+
+            $ttl = \unpack('Nttl', \substr($cacheContent, 0, 4))['ttl'];
+            if ($ttl < \time()) {
+                $this->filesystem->deleteFile($this->directory . '/' . $filename);
+
+                return null;
+            }
+
+            $value = \substr($cacheContent, 4);
+
+            \assert(\is_string($value));
+
+            return $value;
+        } catch (\Throwable) {
+            return null;
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /** @inheritdoc */
+    public function set(string $key, string $value, int $ttl = null): void
+    {
+        if ($ttl < 0) {
+            throw new \Error("Invalid cache TTL ({$ttl}); integer >= 0 or null required");
+        }
+
+        $filename = $this->getFilename($key);
+
+        $lock = $this->lock($filename);
+
+        if ($ttl === null) {
+            $ttl = \PHP_INT_MAX;
+        } else {
+            $ttl = \time() + $ttl;
+        }
+
+        $encodedTtl = \pack('N', $ttl);
+
+        try {
+            $this->filesystem->write($this->directory . '/' . $filename, $encodedTtl . $value);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /** @inheritdoc */
+    public function delete(string $key): ?bool
+    {
+        $filename = $this->getFilename($key);
+
+        $lock = $this->lock($filename);
+
+        try {
+            $this->filesystem->deleteFile($this->directory . '/' . $filename);
+        } catch (FilesystemException) {
+            return false;
+        } finally {
+            $lock->release();
+        }
+        return true;
+    }
+
+    private static function getFilename(string $key): string
+    {
+        return \hash('sha256', $key) . '.cache';
+    }
+
+    private function lock(string $key): Lock
+    {
+        try {
+            return $this->mutex->acquire($key);
+        } catch (\Throwable $exception) {
+            throw new CacheException(
+                \sprintf('Exception thrown when obtaining the lock for key "%s"', $key),
+                0,
+                $exception
+            );
+        }
+    }
+}

--- a/test/FileCacheTest.php
+++ b/test/FileCacheTest.php
@@ -2,70 +2,26 @@
 
 namespace Amp\File\Test;
 
-use Amp\File;
+use Amp\Cache\Test\StringCacheTest;
 use Amp\File\FileCache;
 use Amp\Sync\LocalKeyedMutex;
 
-use function Amp\delay;
-use function Amp\File\filesystem;
-
-class FileCacheTest extends FilesystemTest
+class FileCacheTest extends StringCacheTest
 {
-    protected File\Filesystem $driver;
-
-    public function testGet(): void
-    {
-        $cache = $this->createCache();
-
-        $result = $cache->get("mykey");
-        self::assertNull($result);
-
-        $cache->set("mykey", "myvalue", 10);
-
-        $result = $cache->get("mykey");
-        self::assertSame("myvalue", $result);
-    }
-
-    public function testEntryIsNotReturnedAfterTTLHasPassed(): void
-    {
-        $cache = $this->createCache();
-
-        $cache->set("foo", "bar", 0);
-        delay(1);
-
-        self::assertNull($cache->get("foo"));
-    }
-
-    public function testEntryIsReturnedWhenOverriddenWithNoTimeout(): void
-    {
-        $cache = $this->createCache();
-
-        $cache->set("foo", "bar", 0);
-        $cache->set("foo", "bar");
-        delay(1);
-
-        self::assertNotNull($cache->get("foo"));
-    }
-
-    public function testEntryIsNotReturnedAfterDelete(): void
-    {
-        $cache = $this->createCache();
-
-        $cache->set("foo", "bar");
-        $cache->delete("foo");
-
-        self::assertNull($cache->get("foo"));
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->driver = filesystem();
+        Fixture::init();
     }
 
-    protected function createCache(): FileCache {
-        $fixtureDir = Fixture::path();
-        return new FileCache($fixtureDir, new LocalKeyedMutex, $this->driver);
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Fixture::clear();
+    }
+
+    protected function createCache(): FileCache
+    {
+        return new FileCache(Fixture::path(), new LocalKeyedMutex());
     }
 }

--- a/test/FileCacheTest.php
+++ b/test/FileCacheTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Amp\File\Test;
+
+use Amp\File;
+use Amp\File\FileCache;
+use Amp\Sync\LocalKeyedMutex;
+
+use function Amp\delay;
+use function Amp\File\filesystem;
+
+class FileCacheTest extends FilesystemTest
+{
+    protected File\Filesystem $driver;
+
+    public function testGet(): void
+    {
+        $cache = $this->createCache();
+
+        $result = $cache->get("mykey");
+        self::assertNull($result);
+
+        $cache->set("mykey", "myvalue", 10);
+
+        $result = $cache->get("mykey");
+        self::assertSame("myvalue", $result);
+    }
+
+    public function testEntryIsNotReturnedAfterTTLHasPassed(): void
+    {
+        $cache = $this->createCache();
+
+        $cache->set("foo", "bar", 0);
+        delay(1);
+
+        self::assertNull($cache->get("foo"));
+    }
+
+    public function testEntryIsReturnedWhenOverriddenWithNoTimeout(): void
+    {
+        $cache = $this->createCache();
+
+        $cache->set("foo", "bar", 0);
+        $cache->set("foo", "bar");
+        delay(1);
+
+        self::assertNotNull($cache->get("foo"));
+    }
+
+    public function testEntryIsNotReturnedAfterDelete(): void
+    {
+        $cache = $this->createCache();
+
+        $cache->set("foo", "bar");
+        $cache->delete("foo");
+
+        self::assertNull($cache->get("foo"));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->driver = filesystem();
+    }
+
+    protected function createCache(): FileCache {
+        $fixtureDir = Fixture::path();
+        return new FileCache($fixtureDir, new LocalKeyedMutex, $this->driver);
+    }
+}


### PR DESCRIPTION
This class implements a StringCache that utilizes a directory to store the cached data. I pretty much just ported the old FileCache to AMP3. Tests were added as well, but I did't figure out why `composer` didn't check out `Amp\Cache`'s test-directory, so I copied and pasted them.