### PR TITLE
Do not reuse global worker pool for files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "amphp/amp": "^3",
         "amphp/byte-stream": "^2",
         "amphp/cache": "^2",
-        "amphp/parallel": "^2.1",
+        "amphp/parallel": "2.x-dev as 2.3",
         "amphp/sync": "^2",
         "revolt/event-loop": "^1"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "amphp/amp": "^3",
         "amphp/byte-stream": "^2",
         "amphp/cache": "^2",
-        "amphp/parallel": "2.x-dev as 2.3",
+        "amphp/parallel": "^2.3",
         "amphp/sync": "^2",
         "revolt/event-loop": "^1"
     },

--- a/src/Driver/ParallelFilesystemDriver.php
+++ b/src/Driver/ParallelFilesystemDriver.php
@@ -48,11 +48,11 @@ final class ParallelFilesystemDriver implements FilesystemDriver
             );
         }
 
-        $workerLimit ??= match ($pool::class) {
+        $workerLimit ??= $pool ? match ($pool::class) {
             ContextWorkerPool::class => \min(self::DEFAULT_WORKER_LIMIT, $pool->getLimit()),
             DelegatingWorkerPool::class => $pool->getLimit(),
             default => self::DEFAULT_WORKER_LIMIT,
-        };
+        } : self::DEFAULT_WORKER_LIMIT;
 
         if ($workerLimit <= 0) {
             throw new \ValueError("Worker limit must be a positive integer");
@@ -188,10 +188,12 @@ final class ParallelFilesystemDriver implements FilesystemDriver
 
     public function touch(string $path, ?int $modificationTime, ?int $accessTime): void
     {
-        $this->runFileTask(new Internal\FileTask(
-            "touch",
-            [$path, $modificationTime, $accessTime]
-        ));
+        $this->runFileTask(
+            new Internal\FileTask(
+                "touch",
+                [$path, $modificationTime, $accessTime]
+            )
+        );
     }
 
     public function read(string $path): string

--- a/src/Driver/ParallelFilesystemDriver.php
+++ b/src/Driver/ParallelFilesystemDriver.php
@@ -7,6 +7,7 @@ use Amp\File\FilesystemException;
 use Amp\File\Internal;
 use Amp\Future;
 use Amp\Parallel\Worker\ContextWorkerPool;
+use Amp\Parallel\Worker\DelegatingWorkerPool;
 use Amp\Parallel\Worker\TaskFailureThrowable;
 use Amp\Parallel\Worker\Worker;
 use Amp\Parallel\Worker\WorkerException;
@@ -22,27 +23,43 @@ final class ParallelFilesystemDriver implements FilesystemDriver
     /** @var positive-int Maximum number of workers to use for open files. */
     private readonly int $workerLimit;
 
-    /** @var \SplObjectStorage<Worker, int> Worker storage. */
-    private \SplObjectStorage $workerStorage;
+    /** @var \WeakMap<Worker, int> */
+    private \WeakMap $workerStorage;
 
-    /** @var Future Pending worker request */
-    private Future $pendingWorker;
+    /** @var Future<Worker>|null Pending worker request */
+    private ?Future $pendingWorker = null;
 
     /**
      * @param WorkerPool|null $pool Custom worker pool to use for file workers. If null, a new pool is created.
-     * @param int $workerLimit [Deprecated] Maximum number of workers to use from the pool for open files. Instead of
-     *      using this parameter, provide a pool with a limited number of workers.
+     * @param int|null $workerLimit [Deprecated] Maximum number of workers to use from the pool for open files. Instead
+     *      of using this parameter, provide a pool with a limited number of workers or use {@see DelegatingWorkerPool}.
      */
-    public function __construct(?WorkerPool $pool = null, int $workerLimit = self::DEFAULT_WORKER_LIMIT)
+    public function __construct(?WorkerPool $pool = null, ?int $workerLimit = null)
     {
+        /** @var \WeakMap<Worker, int> For Psalm. */
+        $this->workerStorage = new \WeakMap();
+
+        if ($workerLimit !== null) {
+            \trigger_error(
+                'The $workerLimit parameter is deprecated and will be removed in the next major version.' .
+                ' To limit the number of workers used from the given pool, use ' . DelegatingWorkerPool::class .
+                ' instead.',
+                \E_USER_DEPRECATED,
+            );
+        }
+
+        $workerLimit ??= match ($pool::class) {
+            ContextWorkerPool::class => \min(self::DEFAULT_WORKER_LIMIT, $pool->getLimit()),
+            DelegatingWorkerPool::class => $pool->getLimit(),
+            default => self::DEFAULT_WORKER_LIMIT,
+        };
+
         if ($workerLimit <= 0) {
             throw new \ValueError("Worker limit must be a positive integer");
         }
 
         $this->pool = $pool ?? new ContextWorkerPool($workerLimit);
         $this->workerLimit = $workerLimit;
-        $this->workerStorage = new \SplObjectStorage();
-        $this->pendingWorker = Future::complete();
     }
 
     public function openFile(string $path, string $mode): ParallelFile
@@ -51,12 +68,12 @@ final class ParallelFilesystemDriver implements FilesystemDriver
 
         $workerStorage = $this->workerStorage;
         $worker = new Internal\FileWorker($worker, static function (Worker $worker) use ($workerStorage): void {
-            if (!$workerStorage->contains($worker)) {
+            if (!isset($workerStorage[$worker])) {
                 return;
             }
 
             if (($workerStorage[$worker] -= 1) === 0 || !$worker->isRunning()) {
-                $workerStorage->detach($worker);
+                unset($workerStorage[$worker]);
             }
         });
 
@@ -73,26 +90,19 @@ final class ParallelFilesystemDriver implements FilesystemDriver
 
     private function selectWorker(): Worker
     {
-        $this->pendingWorker->await(); // Wait for any currently pending request for a worker.
+        $this->pendingWorker?->await(); // Wait for any currently pending request for a worker.
 
         if ($this->workerStorage->count() < $this->workerLimit) {
             $this->pendingWorker = async($this->pool->getWorker(...));
             $worker = $this->pendingWorker->await();
 
-            if ($this->workerStorage->contains($worker)) {
-                // amphp/parallel v1.x may return an already used worker from the pool.
-                $this->workerStorage[$worker] += 1;
-            } else {
-                // amphp/parallel v2.x should always return an unused worker.
-                $this->workerStorage->attach($worker, 1);
-            }
+            $this->workerStorage[$worker] = 1;
 
             return $worker;
         }
 
         $max = \PHP_INT_MAX;
-        foreach ($this->workerStorage as $storedWorker) {
-            $count = $this->workerStorage[$storedWorker];
+        foreach ($this->workerStorage as $storedWorker => $count) {
             if ($count <= $max) {
                 $worker = $storedWorker;
                 $max = $count;
@@ -102,7 +112,7 @@ final class ParallelFilesystemDriver implements FilesystemDriver
         \assert(isset($worker) && $worker instanceof Worker);
 
         if (!$worker->isRunning()) {
-            $this->workerStorage->detach($worker);
+            unset($this->workerStorage[$worker]);
             return $this->selectWorker();
         }
 

--- a/src/Driver/ParallelFilesystemDriver.php
+++ b/src/Driver/ParallelFilesystemDriver.php
@@ -30,7 +30,8 @@ final class ParallelFilesystemDriver implements FilesystemDriver
 
     /**
      * @param WorkerPool|null $pool Custom worker pool to use for file workers. If null, a new pool is created.
-     * @param int $workerLimit Maximum number of workers to use from the pool for open files.
+     * @param int $workerLimit [Deprecated] Maximum number of workers to use from the pool for open files. Instead of
+     *      using this parameter, provide a pool with a limited number of workers.
      */
     public function __construct(?WorkerPool $pool = null, int $workerLimit = self::DEFAULT_WORKER_LIMIT)
     {

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,7 +2,6 @@
 
 namespace Amp\File;
 
-use Amp\File\Driver\BlockingFilesystemDriver;
 use Amp\File\Driver\EioFilesystemDriver;
 use Amp\File\Driver\ParallelFilesystemDriver;
 use Amp\File\Driver\StatusCachingFilesystemDriver;
@@ -27,24 +26,10 @@ function filesystem(?FilesystemDriver $driver = null): Filesystem
             return $map[$loop];
         }
 
-        $defaultDriver = createDefaultDriver();
-
-        if (!\defined("AMP_WORKER")) { // Prevent caching in workers, cache in parent instead.
-            $defaultDriver = new StatusCachingFilesystemDriver($defaultDriver);
-        }
-
-        $filesystem = new Filesystem($defaultDriver);
-    } else {
-        $filesystem = new Filesystem($driver);
+        $driver = new StatusCachingFilesystemDriver(createDefaultDriver());
     }
 
-    if (\defined("AMP_WORKER") && $driver instanceof ParallelFilesystemDriver) {
-        throw new \Error("Cannot use the parallel driver within a worker");
-    }
-
-    $map[$loop] = $filesystem;
-
-    return $filesystem;
+    return $map[$loop] = new Filesystem($driver);
 }
 
 /**
@@ -60,10 +45,6 @@ function createDefaultDriver(): FilesystemDriver
 
     if (EioFilesystemDriver::isSupported()) {
         return new EioFilesystemDriver($driver);
-    }
-
-    if (\defined("AMP_WORKER")) { // Prevent spawning infinite workers.
-        return new BlockingFilesystemDriver;
     }
 
     return new ParallelFilesystemDriver;

--- a/src/functions.php
+++ b/src/functions.php
@@ -26,7 +26,11 @@ function filesystem(?FilesystemDriver $driver = null): Filesystem
             return $map[$loop];
         }
 
-        $driver = new StatusCachingFilesystemDriver(createDefaultDriver());
+        $driver = createDefaultDriver();
+
+        if (!\defined("AMP_WORKER")) { // Prevent caching in workers, cache in parent instead.
+            $driver = new StatusCachingFilesystemDriver($driver);
+        }
     }
 
     return $map[$loop] = new Filesystem($driver);


### PR DESCRIPTION
This modifies the parallel driver to create its own internal pool by default, rather than reuse the global worker pool. A specific pool can still be passed to the constructor (though I assume this use is rather rare).

The `AMP_WORKER` constant is no longer used to prevent the blocking driver from being used. This way, a `Task` may still use async file access and get the behavior expected.

/cc @azjezz