### PR TITLE
flock-based File Mutex

### DIFF
--- a/src/FileMutex.php
+++ b/src/FileMutex.php
@@ -44,15 +44,7 @@ final class FileMutex implements Mutex
 
             try {
                 $handle = \fopen($this->fileName, 'c');
-                if (!$handle) {
-                    throw new SyncException(\sprintf(
-                        'Unable to open or create file at %s: %s',
-                        $this->fileName,
-                        \error_get_last()['message'] ?? 'Unknown error',
-                    ));
-                }
-
-                if (\flock($handle, \LOCK_EX | \LOCK_NB)) {
+                if ($handle && \flock($handle, \LOCK_EX | \LOCK_NB)) {
                     return new Lock(fn () => $this->release($handle));
                 }
             } finally {

--- a/src/KeyedFileMutex.php
+++ b/src/KeyedFileMutex.php
@@ -6,13 +6,9 @@ use Amp\Cancellation;
 use Amp\Sync\KeyedMutex;
 use Amp\Sync\Lock;
 use Amp\Sync\SyncException;
-use function Amp\delay;
 
 final class KeyedFileMutex implements KeyedMutex
 {
-    private const LATENCY_TIMEOUT = 0.01;
-    private const DELAY_LIMIT = 1;
-
     private readonly Filesystem $filesystem;
 
     private readonly string $directory;
@@ -26,47 +22,14 @@ final class KeyedFileMutex implements KeyedMutex
         $this->directory = \rtrim($directory, "/\\");
     }
 
-    public function acquire(string $key, ?Cancellation $cancellation = null): Lock
-    {
-        if (!$this->filesystem->isDirectory($this->directory)) {
-            throw new SyncException(\sprintf('Directory "%s" does not exist or is not a directory', $this->directory));
-        }
-
-        $filename = $this->getFilename($key);
-
-        // Try to create the lock file. If the file already exists, someone else
-        // has the lock, so set an asynchronous timer and try again.
-        for ($attempt = 0; true; ++$attempt) {
-            try {
-                $file = $this->filesystem->openFile($filename, 'x');
-
-                // Return a lock object that can be used to release the lock on the mutex.
-                $lock = new Lock(fn () => $this->release($filename));
-
-                $file->close();
-
-                return $lock;
-            } catch (FilesystemException) {
-                delay(\min(self::DELAY_LIMIT, self::LATENCY_TIMEOUT * (2 ** $attempt)), cancellation: $cancellation);
-            }
-        }
-    }
-
     /**
-     * Releases the lock on the mutex.
-     *
      * @throws SyncException
      */
-    private function release(string $filename): void
+    public function acquire(string $key, ?Cancellation $cancellation = null): Lock
     {
-        try {
-            $this->filesystem->deleteFile($filename);
-        } catch (\Throwable $exception) {
-            throw new SyncException(
-                'Failed to unlock the mutex file: ' . $filename,
-                previous: $exception,
-            );
-        }
+        $mutex = new FileMutex($this->getFilename($key), $this->filesystem);
+
+        return $mutex->acquire($cancellation);
     }
 
     private function getFilename(string $key): string


### PR DESCRIPTION
An alternative to #80 which combines using `flock` with file deletion to make a best-effort to cleanup temporary files.