### PR TITLE
Add locking to File interface

### DIFF
--- a/composer-require-check.json
+++ b/composer-require-check.json
@@ -20,6 +20,8 @@
         "deleteFile",
         "filesystem",
         "openFile",
+        "lock",
+        "unlock",
         "eio_cancel",
         "eio_chmod",
         "eio_chown",

--- a/composer-require-check.json
+++ b/composer-require-check.json
@@ -21,6 +21,7 @@
         "filesystem",
         "openFile",
         "lock",
+        "tryLock",
         "unlock",
         "eio_cancel",
         "eio_chmod",

--- a/composer-require-check.json
+++ b/composer-require-check.json
@@ -85,7 +85,8 @@
         "uv_fs_utime",
         "uv_fs_write",
         "uv_fs_close",
-        "uv_strerror"
+        "uv_strerror",
+        "Amp\\Process\\IS_WINDOWS"
     ],
     "php-core-extensions": [
         "Core",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,10 @@
         "psr-4": {
             "Amp\\File\\": "src"
         },
-        "files": ["src/functions.php"]
+        "files": [
+            "src/functions.php",
+            "src/Internal/functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Driver/BlockingFile.php
+++ b/src/Driver/BlockingFile.php
@@ -26,7 +26,7 @@ final class BlockingFile implements File, \IteratorAggregate
 
     private readonly DeferredFuture $onClose;
 
-    private ?LockType $lockMode = null;
+    private ?LockType $lockType = null;
 
     /**
      * @param resource $handle An open filesystem descriptor.
@@ -64,20 +64,20 @@ final class BlockingFile implements File, \IteratorAggregate
      */
     public function getLockType(): ?LockType
     {
-        return $this->lockMode;
+        return $this->lockType;
     }
 
     public function lock(LockType $type, ?Cancellation $cancellation = null): void
     {
         Internal\lock($this->path, $this->getFileHandle(), $type, $cancellation);
-        $this->lockMode = $type;
+        $this->lockType = $type;
     }
 
     public function tryLock(LockType $type): bool
     {
         $locked = Internal\tryLock($this->path, $this->getFileHandle(), $type);
         if ($locked) {
-            $this->lockMode = $type;
+            $this->lockType = $type;
         }
 
         return $locked;
@@ -86,7 +86,7 @@ final class BlockingFile implements File, \IteratorAggregate
     public function unlock(): void
     {
         Internal\unlock($this->path, $this->getFileHandle());
-        $this->lockMode = null;
+        $this->lockType = null;
     }
 
     public function read(?Cancellation $cancellation = null, int $length = self::DEFAULT_READ_LENGTH): ?string
@@ -161,7 +161,7 @@ final class BlockingFile implements File, \IteratorAggregate
             throw new StreamException("Failed closing file '{$this->path}'");
         } finally {
             \restore_error_handler();
-            $this->lockMode = null;
+            $this->lockType = null;
         }
     }
 

--- a/src/Driver/BlockingFile.php
+++ b/src/Driver/BlockingFile.php
@@ -9,7 +9,7 @@ use Amp\Cancellation;
 use Amp\DeferredFuture;
 use Amp\File\File;
 use Amp\File\Internal;
-use Amp\File\LockMode;
+use Amp\File\LockType;
 use Amp\File\Whence;
 
 /**
@@ -26,7 +26,7 @@ final class BlockingFile implements File, \IteratorAggregate
 
     private readonly DeferredFuture $onClose;
 
-    private ?LockMode $lockMode = null;
+    private ?LockType $lockMode = null;
 
     /**
      * @param resource $handle An open filesystem descriptor.
@@ -62,15 +62,15 @@ final class BlockingFile implements File, \IteratorAggregate
     /**
      * Returns the currently active lock mode, or null if the file is not locked.
      */
-    public function getLockMode(): ?LockMode
+    public function getLockType(): ?LockType
     {
         return $this->lockMode;
     }
 
-    public function lock(LockMode $mode, ?Cancellation $cancellation = null): void
+    public function lock(LockType $type, ?Cancellation $cancellation = null): void
     {
-        Internal\lock($this->path, $this->getFileHandle(), $mode, $cancellation);
-        $this->lockMode = $mode;
+        Internal\lock($this->path, $this->getFileHandle(), $type, $cancellation);
+        $this->lockMode = $type;
     }
 
     public function unlock(): void

--- a/src/Driver/BlockingFile.php
+++ b/src/Driver/BlockingFile.php
@@ -73,6 +73,16 @@ final class BlockingFile implements File, \IteratorAggregate
         $this->lockMode = $type;
     }
 
+    public function tryLock(LockType $type): bool
+    {
+        $locked = Internal\tryLock($this->path, $this->getFileHandle(), $type);
+        if ($locked) {
+            $this->lockMode = $type;
+        }
+
+        return $locked;
+    }
+
     public function unlock(): void
     {
         Internal\unlock($this->path, $this->getFileHandle());

--- a/src/Driver/EioFile.php
+++ b/src/Driver/EioFile.php
@@ -125,6 +125,7 @@ final class EioFile extends Internal\QueuedWritesFile
             $this->closing->await();
         } finally {
             $this->poll->done();
+            $this->lockMode = null;
         }
     }
 

--- a/src/Driver/EioFile.php
+++ b/src/Driver/EioFile.php
@@ -125,7 +125,7 @@ final class EioFile extends Internal\QueuedWritesFile
             $this->closing->await();
         } finally {
             $this->poll->done();
-            $this->lockMode = null;
+            $this->lockType = null;
         }
     }
 

--- a/src/Driver/EioFile.php
+++ b/src/Driver/EioFile.php
@@ -14,24 +14,34 @@ final class EioFile extends Internal\QueuedWritesFile
 {
     private readonly Internal\EioPoll $poll;
 
-    /** @var resource eio file handle. */
-    private $fh;
+    /** @var int eio file handle resource ID. */
+    private int $fh;
+
+    /** @var resource|closed-resource */
+    private $fd;
 
     private ?Future $closing = null;
 
     private readonly DeferredFuture $onClose;
 
-    /**
-     * @param resource $fh
-     */
-    public function __construct(Internal\EioPoll $poll, $fh, string $path, string $mode, int $size)
+    public function __construct(Internal\EioPoll $poll, int $fh, string $path, string $mode, int $size)
     {
         parent::__construct($path, $mode, $size);
 
         $this->poll = $poll;
         $this->fh = $fh;
+        $this->fd = \fopen('php://fd/' . $this->fh, 'r');
 
         $this->onClose = new DeferredFuture;
+    }
+
+    protected function getFileHandle()
+    {
+        if (!\is_resource($this->fd)) {
+            throw new ClosedException("The file has been closed");
+        }
+
+        return $this->fd;
     }
 
     public function read(?Cancellation $cancellation = null, int $length = self::DEFAULT_READ_LENGTH): ?string
@@ -97,6 +107,10 @@ final class EioFile extends Internal\QueuedWritesFile
         if ($this->closing) {
             $this->closing->await();
             return;
+        }
+
+        if (\is_resource($this->fd)) {
+            \fclose($this->fd);
         }
 
         $this->closing = $this->onClose->getFuture();

--- a/src/Driver/ParallelFile.php
+++ b/src/Driver/ParallelFile.php
@@ -43,7 +43,7 @@ final class ParallelFile implements File, \IteratorAggregate
 
     private readonly DeferredFuture $onClose;
 
-    private ?LockType $lockMode = null;
+    private ?LockType $lockType = null;
 
     public function __construct(
         private readonly Internal\FileWorker $worker,
@@ -96,7 +96,7 @@ final class ParallelFile implements File, \IteratorAggregate
             $this->closing->await();
         } finally {
             $this->onClose->complete();
-            $this->lockMode = null;
+            $this->lockType = null;
         }
     }
 
@@ -149,14 +149,14 @@ final class ParallelFile implements File, \IteratorAggregate
     public function lock(LockType $type, ?Cancellation $cancellation = null): void
     {
         $this->flock('lock', $type, $cancellation);
-        $this->lockMode = $type;
+        $this->lockType = $type;
     }
 
     public function tryLock(LockType $type): bool
     {
         $locked = $this->flock('try-lock', $type);
         if ($locked) {
-            $this->lockMode = $type;
+            $this->lockType = $type;
         }
 
         return $locked;
@@ -165,12 +165,12 @@ final class ParallelFile implements File, \IteratorAggregate
     public function unlock(): void
     {
         $this->flock('unlock');
-        $this->lockMode = null;
+        $this->lockType = null;
     }
 
     public function getLockType(): ?LockType
     {
-        return $this->lockMode;
+        return $this->lockType;
     }
 
     private function flock(string $action, ?LockType $type = null, ?Cancellation $cancellation = null): bool

--- a/src/Driver/StatusCachingFile.php
+++ b/src/Driver/StatusCachingFile.php
@@ -54,14 +54,19 @@ final class StatusCachingFile implements File, \IteratorAggregate
         }
     }
 
-    public function lock(LockMode $mode): bool
+    public function lock(LockMode $mode, ?Cancellation $cancellation = null): void
     {
-        return $this->file->lock($mode);
+        $this->file->lock($mode, $cancellation);
     }
 
     public function unlock(): void
     {
         $this->file->unlock();
+    }
+
+    public function getLockMode(): ?LockMode
+    {
+        return $this->file->getLockMode();
     }
 
     public function close(): void

--- a/src/Driver/StatusCachingFile.php
+++ b/src/Driver/StatusCachingFile.php
@@ -5,6 +5,7 @@ namespace Amp\File\Driver;
 use Amp\ByteStream\ReadableStreamIteratorAggregate;
 use Amp\Cancellation;
 use Amp\File\File;
+use Amp\File\LockMode;
 use Amp\File\Whence;
 
 /**
@@ -51,6 +52,16 @@ final class StatusCachingFile implements File, \IteratorAggregate
         } finally {
             $this->invalidate();
         }
+    }
+
+    public function lock(LockMode $mode): bool
+    {
+        return $this->file->lock($mode);
+    }
+
+    public function unlock(): void
+    {
+        $this->file->unlock();
     }
 
     public function close(): void

--- a/src/Driver/StatusCachingFile.php
+++ b/src/Driver/StatusCachingFile.php
@@ -59,6 +59,11 @@ final class StatusCachingFile implements File, \IteratorAggregate
         $this->file->lock($type, $cancellation);
     }
 
+    public function tryLock(LockType $type): bool
+    {
+        return $this->file->tryLock($type);
+    }
+
     public function unlock(): void
     {
         $this->file->unlock();

--- a/src/Driver/StatusCachingFile.php
+++ b/src/Driver/StatusCachingFile.php
@@ -5,7 +5,7 @@ namespace Amp\File\Driver;
 use Amp\ByteStream\ReadableStreamIteratorAggregate;
 use Amp\Cancellation;
 use Amp\File\File;
-use Amp\File\LockMode;
+use Amp\File\LockType;
 use Amp\File\Whence;
 
 /**
@@ -54,9 +54,9 @@ final class StatusCachingFile implements File, \IteratorAggregate
         }
     }
 
-    public function lock(LockMode $mode, ?Cancellation $cancellation = null): void
+    public function lock(LockType $type, ?Cancellation $cancellation = null): void
     {
-        $this->file->lock($mode, $cancellation);
+        $this->file->lock($type, $cancellation);
     }
 
     public function unlock(): void
@@ -64,9 +64,9 @@ final class StatusCachingFile implements File, \IteratorAggregate
         $this->file->unlock();
     }
 
-    public function getLockMode(): ?LockMode
+    public function getLockType(): ?LockType
     {
-        return $this->file->getLockMode();
+        return $this->file->getLockType();
     }
 
     public function close(): void

--- a/src/Driver/UvFile.php
+++ b/src/Driver/UvFile.php
@@ -124,7 +124,7 @@ final class UvFile extends Internal\QueuedWritesFile
             $this->closing->await();
         } finally {
             $this->poll->done();
-            $this->lockMode = null;
+            $this->lockType = null;
         }
     }
 

--- a/src/Driver/UvFile.php
+++ b/src/Driver/UvFile.php
@@ -46,6 +46,15 @@ final class UvFile extends Internal\QueuedWritesFile
         $this->onClose = new DeferredFuture;
     }
 
+    protected function getFileHandle()
+    {
+        if ($this->closing) {
+            throw new ClosedException("The file has been closed");
+        }
+
+        return $this->fh;
+    }
+
     public function read(?Cancellation $cancellation = null, int $length = self::DEFAULT_READ_LENGTH): ?string
     {
         if ($this->isReading || !$this->queue->isEmpty()) {

--- a/src/Driver/UvFile.php
+++ b/src/Driver/UvFile.php
@@ -124,6 +124,7 @@ final class UvFile extends Internal\QueuedWritesFile
             $this->closing->await();
         } finally {
             $this->poll->done();
+            $this->lockMode = null;
         }
     }
 

--- a/src/File.php
+++ b/src/File.php
@@ -6,7 +6,6 @@ use Amp\ByteStream\ClosedException;
 use Amp\ByteStream\ReadableStream;
 use Amp\ByteStream\WritableStream;
 use Amp\Cancellation;
-use Amp\Sync\Lock;
 
 interface File extends ReadableStream, WritableStream
 {
@@ -58,12 +57,22 @@ interface File extends ReadableStream, WritableStream
     public function truncate(int $size): void;
 
     /**
-     * Non-blocking method to obtain a shared or exclusive lock on the file.
+     * Non-blocking method to obtain a shared or exclusive lock on the file. This method must only return once
+     * the lock has been obtained. Use {@see tryLock()} to make a single attempt to get the lock.
      *
      * @throws FilesystemException If there is an error when attempting to lock the file.
      * @throws ClosedException If the file has been closed.
      */
     public function lock(LockType $type, ?Cancellation $cancellation = null): void;
+
+    /**
+     * Make a single non-blocking attempt to obtain a shared or exclusive lock on the file. Returns true if the lock
+     * was obtained, otherwise false. Use {@see lock()} to return only once the lock is obtained.
+     *
+     * @throws FilesystemException If there is an error when attempting to lock the file.
+     * @throws ClosedException If the file has been closed.
+     */
+    public function tryLock(LockType $type): bool;
 
     /**
      * @throws FilesystemException If there is an error when attempting to unlock the file.

--- a/src/File.php
+++ b/src/File.php
@@ -2,6 +2,7 @@
 
 namespace Amp\File;
 
+use Amp\ByteStream\ClosedException;
 use Amp\ByteStream\ReadableStream;
 use Amp\ByteStream\WritableStream;
 use Amp\Cancellation;
@@ -54,4 +55,16 @@ interface File extends ReadableStream, WritableStream
      * @param int $size New file size.
      */
     public function truncate(int $size): void;
+
+    /**
+     * Makes a non-blocking attempt to lock the file. Returns true if the lock was obtained.
+     *
+     * @throws ClosedException If the file has been closed.
+     */
+    public function lock(LockMode $mode): bool;
+
+    /**
+     * @throws ClosedException If the file has been closed.
+     */
+    public function unlock(): void;
 }

--- a/src/File.php
+++ b/src/File.php
@@ -6,6 +6,7 @@ use Amp\ByteStream\ClosedException;
 use Amp\ByteStream\ReadableStream;
 use Amp\ByteStream\WritableStream;
 use Amp\Cancellation;
+use Amp\Sync\Lock;
 
 interface File extends ReadableStream, WritableStream
 {
@@ -57,16 +58,21 @@ interface File extends ReadableStream, WritableStream
     public function truncate(int $size): void;
 
     /**
-     * Makes a non-blocking attempt to lock the file. Returns true if the lock was obtained.
+     * Non-blocking method to obtain a shared or exclusive lock on the file.
      *
      * @throws FilesystemException If there is an error when attempting to lock the file.
      * @throws ClosedException If the file has been closed.
      */
-    public function lock(LockMode $mode): bool;
+    public function lock(LockMode $mode, ?Cancellation $cancellation = null): void;
 
     /**
      * @throws FilesystemException If there is an error when attempting to unlock the file.
      * @throws ClosedException If the file has been closed.
      */
     public function unlock(): void;
+
+    /**
+     * Returns the currently active lock mode, or null if the file is not locked.
+     */
+    public function getLockMode(): ?LockMode;
 }

--- a/src/File.php
+++ b/src/File.php
@@ -63,7 +63,7 @@ interface File extends ReadableStream, WritableStream
      * @throws FilesystemException If there is an error when attempting to lock the file.
      * @throws ClosedException If the file has been closed.
      */
-    public function lock(LockMode $mode, ?Cancellation $cancellation = null): void;
+    public function lock(LockType $type, ?Cancellation $cancellation = null): void;
 
     /**
      * @throws FilesystemException If there is an error when attempting to unlock the file.
@@ -72,7 +72,7 @@ interface File extends ReadableStream, WritableStream
     public function unlock(): void;
 
     /**
-     * Returns the currently active lock mode, or null if the file is not locked.
+     * Returns the currently active lock type, or null if the file is not locked.
      */
-    public function getLockMode(): ?LockMode;
+    public function getLockType(): ?LockType;
 }

--- a/src/File.php
+++ b/src/File.php
@@ -59,11 +59,13 @@ interface File extends ReadableStream, WritableStream
     /**
      * Makes a non-blocking attempt to lock the file. Returns true if the lock was obtained.
      *
+     * @throws FilesystemException If there is an error when attempting to lock the file.
      * @throws ClosedException If the file has been closed.
      */
     public function lock(LockMode $mode): bool;
 
     /**
+     * @throws FilesystemException If there is an error when attempting to unlock the file.
      * @throws ClosedException If the file has been closed.
      */
     public function unlock(): void;

--- a/src/FileMutex.php
+++ b/src/FileMutex.php
@@ -39,7 +39,7 @@ final class FileMutex implements Mutex
         // so set an asynchronous timer and try again.
         for ($attempt = 0; true; ++$attempt) {
             try {
-                $file = $this->filesystem->openFile($this->fileName, 'c');
+                $file = $this->filesystem->openFile($this->fileName, 'a');
                 if ($file->lock(LockMode::Exclusive)) {
                     return new Lock(fn () => $this->release($file));
                 }

--- a/src/FileMutex.php
+++ b/src/FileMutex.php
@@ -52,7 +52,7 @@ final class FileMutex implements Mutex
                 try {
                     $file = $this->filesystem->openFile($this->fileName, 'a');
 
-                    $file->lock(LockMode::Exclusive, $cancellation);
+                    $file->lock(LockType::Exclusive, $cancellation);
                     return new Lock(fn () => $this->release($file, $deferredFuture));
                 } catch (FilesystemException|StreamException $exception) {
                     if (!IS_WINDOWS) {

--- a/src/FileMutex.php
+++ b/src/FileMutex.php
@@ -7,8 +7,8 @@ use Amp\Cancellation;
 use Amp\Sync\Lock;
 use Amp\Sync\Mutex;
 use Amp\Sync\SyncException;
-use function Amp\delay;
 use const Amp\Process\IS_WINDOWS;
+use function Amp\delay;
 
 final class FileMutex implements Mutex
 {

--- a/src/FileMutex.php
+++ b/src/FileMutex.php
@@ -60,8 +60,7 @@ final class FileMutex implements Mutex
                     }
 
                     // Windows fails to open the file if a lock is held.
-                    $multiplier = 2 ** \min(7, $attempt);
-                    delay(\min(self::DELAY_LIMIT, self::LATENCY_TIMEOUT * $multiplier), cancellation: $cancellation);
+                    delay(\min(self::DELAY_LIMIT, self::LATENCY_TIMEOUT * (2 ** $attempt)), cancellation: $cancellation);
                 }
             }
         } catch (FilesystemException|StreamException $exception) {

--- a/src/Internal/FileTask.php
+++ b/src/Internal/FileTask.php
@@ -101,12 +101,20 @@ final class FileTask implements Task
                     return null;
 
                 case "flock":
-                    [$mode] = $this->args;
-                    if ($mode) {
-                        return $file->lock($mode);
+                    [$mode, $action] = $this->args;
+                    switch ($action) {
+                        case 'lock':
+                            $file->lock($mode, $cancellation);
+                            break;
+
+                        case 'unlock':
+                            $file->unlock();
+                            break;
+
+                        default:
+                            throw new \Error("Invalid lock action - " . $action);
                     }
 
-                    $file->unlock();
                     return null;
 
                 default:

--- a/src/Internal/FileTask.php
+++ b/src/Internal/FileTask.php
@@ -54,8 +54,7 @@ final class FileTask implements Task
             if ("fopen" === $this->operation) {
                 $file = $driver->openFile(...$this->args);
 
-                $size = $driver->getStatus($file->getPath())["size"]
-                    ?? throw new FilesystemException("Could not determine file size");
+                $size = $driver->getStatus($file->getPath())["size"] ?? 0;
 
                 $id = $file->getId();
                 $cache->set((string) $id, $file);

--- a/src/Internal/FileTask.php
+++ b/src/Internal/FileTask.php
@@ -102,10 +102,10 @@ final class FileTask implements Task
                     return null;
 
                 case "flock":
-                    [$mode, $action] = $this->args;
+                    [$type, $action] = $this->args;
                     switch ($action) {
                         case 'lock':
-                            $file->lock($mode, $cancellation);
+                            $file->lock($type, $cancellation);
                             break;
 
                         case 'unlock':

--- a/src/Internal/FileTask.php
+++ b/src/Internal/FileTask.php
@@ -101,6 +101,15 @@ final class FileTask implements Task
                     $file->close();
                     return null;
 
+                case "flock":
+                    [$mode] = $this->args;
+                    if ($mode) {
+                        return $file->lock($mode);
+                    }
+
+                    $file->unlock();
+                    return null;
+
                 default:
                     throw new \Error('Invalid operation');
             }

--- a/src/Internal/FileTask.php
+++ b/src/Internal/FileTask.php
@@ -54,7 +54,8 @@ final class FileTask implements Task
             if ("fopen" === $this->operation) {
                 $file = $driver->openFile(...$this->args);
 
-                $size = $driver->getStatus($file->getPath())["size"] ?? 0;
+                $size = $driver->getStatus($file->getPath())["size"]
+                    ?? throw new FilesystemException("Could not determine file size");
 
                 $id = $file->getId();
                 $cache->set((string) $id, $file);

--- a/src/Internal/FileTask.php
+++ b/src/Internal/FileTask.php
@@ -106,17 +106,20 @@ final class FileTask implements Task
                     switch ($action) {
                         case 'lock':
                             $file->lock($type, $cancellation);
-                            break;
+                            return true;
+
+                        case 'try-lock':
+                            return $file->tryLock($type);
 
                         case 'unlock':
                             $file->unlock();
-                            break;
+                            return true;
 
                         default:
                             throw new \Error("Invalid lock action - " . $action);
                     }
 
-                    return null;
+                    return false; // CS fixer fails without this return.
 
                 default:
                     throw new \Error('Invalid operation');

--- a/src/Internal/QueuedWritesFile.php
+++ b/src/Internal/QueuedWritesFile.php
@@ -29,7 +29,7 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
 
     private bool $writable;
 
-    private ?LockMode $lockMode = null;
+    protected ?LockMode $lockMode = null;
 
     public function __construct(
         private readonly string $path,

--- a/src/Internal/QueuedWritesFile.php
+++ b/src/Internal/QueuedWritesFile.php
@@ -6,7 +6,7 @@ use Amp\ByteStream\ClosedException;
 use Amp\ByteStream\ReadableStreamIteratorAggregate;
 use Amp\Cancellation;
 use Amp\File\File;
-use Amp\File\LockMode;
+use Amp\File\LockType;
 use Amp\File\PendingOperationError;
 use Amp\File\Whence;
 use Amp\Future;
@@ -29,7 +29,7 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
 
     private bool $writable;
 
-    protected ?LockMode $lockMode = null;
+    protected ?LockType $lockMode = null;
 
     public function __construct(
         private readonly string $path,
@@ -131,10 +131,10 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
      */
     abstract protected function getFileHandle();
 
-    public function lock(LockMode $mode, ?Cancellation $cancellation = null): void
+    public function lock(LockType $type, ?Cancellation $cancellation = null): void
     {
-        lock($this->getPath(), $this->getFileHandle(), $mode, $cancellation);
-        $this->lockMode = $mode;
+        lock($this->getPath(), $this->getFileHandle(), $type, $cancellation);
+        $this->lockMode = $type;
     }
 
     public function unlock(): void
@@ -143,7 +143,7 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
         $this->lockMode = null;
     }
 
-    public function getLockMode(): ?LockMode
+    public function getLockType(): ?LockType
     {
         return $this->lockMode;
     }

--- a/src/Internal/QueuedWritesFile.php
+++ b/src/Internal/QueuedWritesFile.php
@@ -29,6 +29,8 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
 
     private bool $writable;
 
+    private ?LockMode $lockMode = null;
+
     public function __construct(
         private readonly string $path,
         private readonly string $mode,
@@ -129,14 +131,21 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
      */
     abstract protected function getFileHandle();
 
-    public function lock(LockMode $mode): bool
+    public function lock(LockMode $mode, ?Cancellation $cancellation = null): void
     {
-        return lock($this->getPath(), $this->getFileHandle(), $mode);
+        lock($this->getPath(), $this->getFileHandle(), $mode, $cancellation);
+        $this->lockMode = $mode;
     }
 
     public function unlock(): void
     {
         unlock($this->getPath(), $this->getFileHandle());
+        $this->lockMode = null;
+    }
+
+    public function getLockMode(): ?LockMode
+    {
+        return $this->lockMode;
     }
 
     public function seek(int $position, Whence $whence = Whence::Start): int

--- a/src/Internal/QueuedWritesFile.php
+++ b/src/Internal/QueuedWritesFile.php
@@ -29,7 +29,7 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
 
     private bool $writable;
 
-    protected ?LockType $lockMode = null;
+    protected ?LockType $lockType = null;
 
     public function __construct(
         private readonly string $path,
@@ -134,14 +134,14 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
     public function lock(LockType $type, ?Cancellation $cancellation = null): void
     {
         lock($this->path, $this->getFileHandle(), $type, $cancellation);
-        $this->lockMode = $type;
+        $this->lockType = $type;
     }
 
     public function tryLock(LockType $type): bool
     {
         $locked = tryLock($this->path, $this->getFileHandle(), $type);
         if ($locked) {
-            $this->lockMode = $type;
+            $this->lockType = $type;
         }
 
         return $locked;
@@ -150,12 +150,12 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
     public function unlock(): void
     {
         unlock($this->path, $this->getFileHandle());
-        $this->lockMode = null;
+        $this->lockType = null;
     }
 
     public function getLockType(): ?LockType
     {
-        return $this->lockMode;
+        return $this->lockType;
     }
 
     public function seek(int $position, Whence $whence = Whence::Start): int

--- a/src/Internal/QueuedWritesFile.php
+++ b/src/Internal/QueuedWritesFile.php
@@ -133,13 +133,23 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
 
     public function lock(LockType $type, ?Cancellation $cancellation = null): void
     {
-        lock($this->getPath(), $this->getFileHandle(), $type, $cancellation);
+        lock($this->path, $this->getFileHandle(), $type, $cancellation);
         $this->lockMode = $type;
+    }
+
+    public function tryLock(LockType $type): bool
+    {
+        $locked = tryLock($this->path, $this->getFileHandle(), $type);
+        if ($locked) {
+            $this->lockMode = $type;
+        }
+
+        return $locked;
     }
 
     public function unlock(): void
     {
-        unlock($this->getPath(), $this->getFileHandle());
+        unlock($this->path, $this->getFileHandle());
         $this->lockMode = null;
     }
 

--- a/src/Internal/QueuedWritesFile.php
+++ b/src/Internal/QueuedWritesFile.php
@@ -6,6 +6,7 @@ use Amp\ByteStream\ClosedException;
 use Amp\ByteStream\ReadableStreamIteratorAggregate;
 use Amp\Cancellation;
 use Amp\File\File;
+use Amp\File\LockMode;
 use Amp\File\PendingOperationError;
 use Amp\File\Whence;
 use Amp\Future;
@@ -119,6 +120,23 @@ abstract class QueuedWritesFile implements File, \IteratorAggregate
         $this->queue->push($future);
 
         $future->await();
+    }
+
+    /**
+     * @return resource
+     *
+     * @throws ClosedException If the file has been closed.
+     */
+    abstract protected function getFileHandle();
+
+    public function lock(LockMode $mode): bool
+    {
+        return lock($this->getPath(), $this->getFileHandle(), $mode);
+    }
+
+    public function unlock(): void
+    {
+        unlock($this->getPath(), $this->getFileHandle());
     }
 
     public function seek(int $position, Whence $whence = Whence::Start): int

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Amp\File\Internal;
+
+use Amp\File\FilesystemException;
+use Amp\File\LockMode;
+
+/**
+ * @internal
+ *
+ * @param resource $handle
+ *
+ * @throws FilesystemException
+ */
+function lock(string $path, $handle, LockMode $mode): bool
+{
+    $error = null;
+    \set_error_handler(static function (int $type, string $message) use (&$error): bool {
+        $error = $message;
+        return true;
+    });
+
+    try {
+        $flag = $mode === LockMode::Exclusive ? \LOCK_EX : \LOCK_SH;
+        $lock = \flock($handle, $flag | \LOCK_NB, $wouldBlock);
+    } finally {
+        \restore_error_handler();
+    }
+
+    if ($lock) {
+        return true;
+    }
+
+    if (!$wouldBlock) {
+        throw new FilesystemException(\sprintf(
+            'Error attempting to lock file at "%s": %s',
+            $path,
+            $error ?? 'Unknown error',
+        ));
+    }
+
+    return false;
+}
+
+/**
+ * @internal
+ *
+ * @param resource $handle
+ *
+ * @throws FilesystemException
+ */
+function unlock(string $path, $handle): bool
+{
+    \set_error_handler(static function (int $type, string $message) use ($path): never {
+        throw new FilesystemException(\sprintf('Error attempting to unlock file at "%s": %s', $path, $message));
+    });
+
+    try {
+        \flock($handle, \LOCK_UN);
+    } finally {
+        \restore_error_handler();
+    }
+
+    return true;
+}

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -4,7 +4,7 @@ namespace Amp\File\Internal;
 
 use Amp\Cancellation;
 use Amp\File\FilesystemException;
-use Amp\File\LockMode;
+use Amp\File\LockType;
 use function Amp\delay;
 
 /**
@@ -14,7 +14,7 @@ use function Amp\delay;
  *
  * @throws FilesystemException
  */
-function lock(string $path, $handle, LockMode $mode, ?Cancellation $cancellation): void
+function lock(string $path, $handle, LockType $type, ?Cancellation $cancellation): void
 {
     static $latencyTimeout = 0.01;
     static $delayLimit = 1;
@@ -25,9 +25,9 @@ function lock(string $path, $handle, LockMode $mode, ?Cancellation $cancellation
         return true;
     };
 
-    $flags = \LOCK_NB | match ($mode) {
-        LockMode::Shared => \LOCK_SH,
-        LockMode::Exclusive => \LOCK_EX,
+    $flags = \LOCK_NB | match ($type) {
+        LockType::Shared => \LOCK_SH,
+        LockType::Exclusive => \LOCK_EX,
     };
 
     for ($attempt = 0; true; ++$attempt) {

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -52,8 +52,7 @@ function lock(string $path, $handle, LockMode $mode, ?Cancellation $cancellation
             );
         }
 
-        $multiplier = 2 ** \min(7, $attempt);
-        delay(\min($delayLimit, $latencyTimeout * $multiplier), cancellation: $cancellation);
+        delay(\min($delayLimit, $latencyTimeout * (2 ** $attempt)), cancellation: $cancellation);
     }
 }
 

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -2,8 +2,10 @@
 
 namespace Amp\File\Internal;
 
+use Amp\Cancellation;
 use Amp\File\FilesystemException;
 use Amp\File\LockMode;
+use function Amp\delay;
 
 /**
  * @internal
@@ -12,34 +14,47 @@ use Amp\File\LockMode;
  *
  * @throws FilesystemException
  */
-function lock(string $path, $handle, LockMode $mode): bool
+function lock(string $path, $handle, LockMode $mode, ?Cancellation $cancellation): void
 {
+    static $latencyTimeout = 0.01;
+    static $delayLimit = 1;
+
     $error = null;
-    \set_error_handler(static function (int $type, string $message) use (&$error): bool {
+    $errorHandler = static function (int $type, string $message) use (&$error): bool {
         $error = $message;
         return true;
-    });
+    };
 
-    try {
-        $flag = $mode === LockMode::Exclusive ? \LOCK_EX : \LOCK_SH;
-        $lock = \flock($handle, $flag | \LOCK_NB, $wouldBlock);
-    } finally {
-        \restore_error_handler();
+    $flags = \LOCK_NB | match ($mode) {
+        LockMode::Shared => \LOCK_SH,
+        LockMode::Exclusive => \LOCK_EX,
+    };
+
+    for ($attempt = 0; true; ++$attempt) {
+        \set_error_handler($errorHandler);
+        try {
+            $lock = \flock($handle, $flags, $wouldBlock);
+        } finally {
+            \restore_error_handler();
+        }
+
+        if ($lock) {
+            return;
+        }
+
+        if (!$wouldBlock) {
+            throw new FilesystemException(
+                \sprintf(
+                    'Error attempting to lock file at "%s": %s',
+                    $path,
+                    $error ?? 'Unknown error',
+                )
+            );
+        }
+
+        $multiplier = 2 ** \min(7, $attempt);
+        delay(\min($delayLimit, $latencyTimeout * $multiplier), cancellation: $cancellation);
     }
-
-    if ($lock) {
-        return true;
-    }
-
-    if (!$wouldBlock) {
-        throw new FilesystemException(\sprintf(
-            'Error attempting to lock file at "%s": %s',
-            $path,
-            $error ?? 'Unknown error',
-        ));
-    }
-
-    return false;
 }
 
 /**

--- a/src/KeyedFileMutex.php
+++ b/src/KeyedFileMutex.php
@@ -6,13 +6,9 @@ use Amp\Cancellation;
 use Amp\Sync\KeyedMutex;
 use Amp\Sync\Lock;
 use Amp\Sync\SyncException;
-use function Amp\delay;
 
 final class KeyedFileMutex implements KeyedMutex
 {
-    private const LATENCY_TIMEOUT = 0.01;
-    private const DELAY_LIMIT = 1;
-
     private readonly Filesystem $filesystem;
 
     private readonly string $directory;
@@ -26,47 +22,14 @@ final class KeyedFileMutex implements KeyedMutex
         $this->directory = \rtrim($directory, "/\\");
     }
 
-    public function acquire(string $key, ?Cancellation $cancellation = null): Lock
-    {
-        if (!$this->filesystem->isDirectory($this->directory)) {
-            throw new SyncException(\sprintf('Directory "%s" does not exist or is not a directory', $this->directory));
-        }
-
-        $filename = $this->getFilename($key);
-
-        // Try to create the lock file. If the file already exists, someone else
-        // has the lock, so set an asynchronous timer and try again.
-        for ($attempt = 0; true; ++$attempt) {
-            try {
-                $file = $this->filesystem->openFile($filename, 'x');
-
-                // Return a lock object that can be used to release the lock on the mutex.
-                $lock = new Lock(fn () => $this->release($filename));
-
-                $file->close();
-
-                return $lock;
-            } catch (FilesystemException) {
-                delay(\min(self::DELAY_LIMIT, self::LATENCY_TIMEOUT * (2 ** $attempt)), cancellation: $cancellation);
-            }
-        }
-    }
-
     /**
-     * Releases the lock on the mutex.
-     *
      * @throws SyncException
      */
-    private function release(string $filename): void
+    public function acquire(string $key, ?Cancellation $cancellation = null): Lock
     {
-        try {
-            $this->filesystem->deleteFile($filename);
-        } catch (\Throwable $exception) {
-            throw new SyncException(
-                'Failed to unlock the mutex file: ' . $filename,
-                previous: $exception,
-            );
-        }
+        $mutex = new FileMutex($this->getFilename($key), $this->filesystem);
+
+        return $mutex->acquire($cancellation);
     }
 
     private function getFilename(string $key): string

--- a/src/LockMode.php
+++ b/src/LockMode.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Amp\File;
+
+enum LockMode
+{
+    case Shared;
+    case Exclusive;
+}

--- a/src/LockType.php
+++ b/src/LockType.php
@@ -2,7 +2,7 @@
 
 namespace Amp\File;
 
-enum LockMode
+enum LockType
 {
     case Shared;
     case Exclusive;

--- a/test/AsyncFileTest.php
+++ b/test/AsyncFileTest.php
@@ -5,7 +5,7 @@ namespace Amp\File\Test;
 use Amp\CancelledException;
 use Amp\DeferredCancellation;
 use Amp\File;
-use Amp\File\LockMode;
+use Amp\File\LockType;
 use Amp\File\PendingOperationError;
 use Revolt\EventLoop;
 use function Amp\async;
@@ -106,8 +106,8 @@ abstract class AsyncFileTest extends FileTest
         $handle1 = $this->driver->openFile($path, "c+");
         $handle2 = $this->driver->openFile($path, "c+");
 
-        $future1 = async(fn () => $handle1->lock(LockMode::Exclusive));
-        $future2 = async(fn () => $handle2->lock(LockMode::Exclusive));
+        $future1 = async(fn () => $handle1->lock(LockType::Exclusive));
+        $future2 = async(fn () => $handle2->lock(LockType::Exclusive));
 
         EventLoop::delay(0.1, fn () => $handle1->unlock());
 

--- a/test/AsyncFileTest.php
+++ b/test/AsyncFileTest.php
@@ -111,12 +111,13 @@ abstract class AsyncFileTest extends FileTest
 
         EventLoop::delay(0.1, function () use ($handle1, $handle2): void {
             // Either file could obtain the lock first, so check both and release the one which obtained the lock.
-
             if ($handle1->getLockType()) {
+                self::assertNull($handle2->getLockType());
+                self::assertSame(LockType::Exclusive, $handle1->getLockType());
                 $handle1->unlock();
-            }
-
-            if ($handle2->getLockType()) {
+            } else {
+                self::assertNull($handle1->getLockType());
+                self::assertSame(LockType::Exclusive, $handle2->getLockType());
                 $handle2->unlock();
             }
         });

--- a/test/FileTest.php
+++ b/test/FileTest.php
@@ -4,7 +4,7 @@ namespace Amp\File\Test;
 
 use Amp\ByteStream\ClosedException;
 use Amp\File;
-use Amp\File\LockMode;
+use Amp\File\LockType;
 use Amp\File\Whence;
 
 use function Amp\async;
@@ -309,14 +309,14 @@ abstract class FileTest extends FilesystemTest
         $path = Fixture::path() . "/lock";
         $handle = $this->driver->openFile($path, "c+");
 
-        $handle->lock(LockMode::Shared);
-        self::assertSame(LockMode::Shared, $handle->getLockMode());
+        $handle->lock(LockType::Shared);
+        self::assertSame(LockType::Shared, $handle->getLockType());
 
-        $handle->lock(LockMode::Exclusive);
-        self::assertSame(LockMode::Exclusive, $handle->getLockMode());
+        $handle->lock(LockType::Exclusive);
+        self::assertSame(LockType::Exclusive, $handle->getLockType());
 
         $handle->unlock();
-        self::assertNull($handle->getLockMode());
+        self::assertNull($handle->getLockType());
 
         $handle->unlock(); // Assert no-op.
 
@@ -328,10 +328,10 @@ abstract class FileTest extends FilesystemTest
         $path = Fixture::path() . "/lock";
         $handle = $this->driver->openFile($path, "c+");
 
-        $handle->lock(LockMode::Exclusive);
+        $handle->lock(LockType::Exclusive);
 
         $handle->close();
-        self::assertNull($handle->getLockMode());
+        self::assertNull($handle->getLockType());
     }
 
     public function testLockAfterClose(): void
@@ -341,7 +341,7 @@ abstract class FileTest extends FilesystemTest
         $handle->close();
 
         $this->expectException(ClosedException::class);
-        $handle->lock(LockMode::Exclusive);
+        $handle->lock(LockType::Exclusive);
     }
 
     public function testUnlockAfterClose(): void


### PR DESCRIPTION
This adds three new methods to the `File` interface: `lock`, `unlock`, and `getLockMode`. As the names imply, these functions provide a non-blocking method obtaining and releasing a shared or exclusive lock on the file. The mode is provided by a new enum, `LockMode` with two cases: `Shared` and `Exclusive`. `lock` tries to obtain the lock in a loop using an exponential-backoff until a lock is obtained or the optional cancellation is cancelled. `getLockMode` returns the current lock mode if the file has been locked or null otherwise.

I've refactored `FileMutex` and `KeyedFileMutex` to use these two new async methods.

I think is a better option than #86, however it will require a new major version since the `File` interface has been modified. I don't consider this a blocker, as most components will be able to require 3.x or 4.x.

**DO NOT merge into `3.x`, we'll need make a `4.x` branch if this is merged.**