### PR TITLE
Fix deprecation warning for parameters implicitly marked as nullable

### DIFF
--- a/src/Driver/ParallelDriver.php
+++ b/src/Driver/ParallelDriver.php
@@ -21,7 +21,7 @@ final class ParallelDriver implements Driver
     /**
      * @param Pool|null $pool
      */
-    public function __construct(Pool $pool = null)
+    public function __construct(?Pool $pool = null)
     {
         $this->pool = $pool ?: Worker\pool();
     }

--- a/src/FilesystemException.php
+++ b/src/FilesystemException.php
@@ -4,7 +4,7 @@ namespace Amp\File;
 
 class FilesystemException extends \Exception
 {
-    public function __construct(string $message, \Throwable $previous = null)
+    public function __construct(string $message, ?\Throwable $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Internal/Cache.php
+++ b/src/Internal/Cache.php
@@ -20,7 +20,7 @@ final class Cache
      *     collected.
      * @param int|null $maxSize The maximum size of cache array (number of elements).
      */
-    public function __construct(int $gcInterval = 1000, int $maxSize = null)
+    public function __construct(int $gcInterval = 1000, ?int $maxSize = null)
     {
         // By using a shared state object we're able to use `__destruct()` for "normal" garbage collection of both this
         // instance and the loop's watcher. Otherwise this object could only be GC'd when the TTL watcher was cancelled
@@ -89,7 +89,7 @@ final class Cache
         return $this->sharedState->cache[$key];
     }
 
-    public function set(string $key, $value, int $ttl = null): void
+    public function set(string $key, $value, ?int $ttl = null): void
     {
         if ($ttl === null) {
             unset($this->sharedState->cacheTimeouts[$key]);

--- a/src/Internal/FileTask.php
+++ b/src/Internal/FileTask.php
@@ -36,7 +36,7 @@ final class FileTask implements Task
      *
      * @throws \Error
      */
-    public function __construct(string $operation, array $args = [], int $id = null)
+    public function __construct(string $operation, array $args = [], ?int $id = null)
     {
         if ($operation === '') {
             throw new \Error('Operation must be a non-empty string');

--- a/src/PendingOperationError.php
+++ b/src/PendingOperationError.php
@@ -7,7 +7,7 @@ final class PendingOperationError extends \Error
     public function __construct(
         string $message = "The previous file operation must complete before another can be started",
         int $code = 0,
-        \Throwable $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
This deprecation is added in PHP 8.4.
